### PR TITLE
Align versions

### DIFF
--- a/vcan-in-wsl2/README.md
+++ b/vcan-in-wsl2/README.md
@@ -1,36 +1,36 @@
+Note: wsl once you replace the wsl linux kernel with the custom kernel, every distribution in wsl will use 
 
 ## Generate SSH key
-Make sure the public SSH key is associated with the GitHub account. 
+Make sure the public SSH key is associated with the GitHub account. [Here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) are some instructions on how to create an ssh key on your machine.
 
 ## WSL CLI
-In Windows, open a WSL terminal and launch `vcan-in-wsl2.sh` script.
+In Windows, open a WSL terminal and launch `vcan-in-wsl2.sh` script:
+```
+./vcan-in-wsl2.sh
+```
 
-You will be asked to continue with the installation of `dwarves v1.21`. Type `y` and `ENTER`.
+You will be asked to continue with the installation of `dwarves v1.21`. Alternative, it could be possible to use a newer version of dwarves by [skipping the btf encoding from the `pahole` invoke in the kernel build](https://unix.stackexchange.com/questions/754325/failed-load-btf-from-vmlinux-invalid-argument-make-on-config-debug-info-btf-y/772051#772051), however this hasn't been tested. Type `y` and `ENTER`.
 
 Accept the default for all the kernel configuration requests.
 
-Subsequently, a linux kernel configuration menu will open. In the `General Setup` section, we need to  enable support for vcan and slcan. Use `ENTER` to access sub-configurations and `M` for module support
-
-`ENTER` Networking support
-
-->`M` CAN bus subsystem support
-
--> `M` ISO 15765-2:2016 CAN transport protocol
-
-`ENTER` Go to CAN Device Drivers
-
--> `M` Virtual Local CAN Interface (vcan)
-
--> `M` Serial / USB serial CAN Adaptors (slcan)
-
--> `M` Kvaser PCIe FD Cards
-
--> `M` PEAK-System PCAN-PCIe FD cards
+Subsequently, a linux kernel configuration menu will open. In the `General Setup` section, we need to  enable support for vcan and slcan.
 
 ## Powershell
 
-Once the `vcan-in-wsl2.sh` script is done, close the wsl terminal and run a powershell as administrator.
+Once the `vcan-in-wsl2.sh` script is done, close the wsl terminal and run a powershell.
 
-From the user home directory, run the `wsl-reboot.ps1` script.
+First, you'll need to temporary bypass the execution policy to run the script. This is achieved by running the following command:
+```
+Set-ExecutionPolicy Bypass -Scope Process
+```
+From the user home directory, run the `wsl-reboot.ps1` script:
+```
+./wsl-reboot.ps1
+```
 
-At completion, open a new wsl terminal and type `uname -a`. If the proces was successful, you should see the `5.15.57.1-microsoft-standard-WSL2+` in the output
+At completion, open a new wsl terminal and type `uname -a`. If the proces was successful, you should see the `5.15.57.1-microsoft-standard-WSL2+` in the output.
+
+Finally, launch the following command to add module from the linux kernel:
+```
+sudo modprobe can; sudo modprobe can-raw; sudo modprobe vcan; sudo modprobe slcan; sudo modprobe can-isotp; sudo modprobe peak_usb; sudo modprobe kvaser_usb
+```

--- a/vcan-in-wsl2/README.md
+++ b/vcan-in-wsl2/README.md
@@ -28,6 +28,8 @@ From the user home directory, run the `wsl-reboot.ps1` script:
 ./wsl-reboot.ps1
 ```
 
+At this point, you might also need to reboot you machine to enable WSL to use the new linux kernel.
+
 At completion, open a new wsl terminal and type `uname -a`. If the process was successful, you should see the `5.15.57.1-microsoft-standard-WSL2+` in the output.
 
 Finally, launch the following command to add module from the linux kernel:

--- a/vcan-in-wsl2/README.md
+++ b/vcan-in-wsl2/README.md
@@ -1,4 +1,4 @@
-Note: wsl once you replace the wsl linux kernel with the custom kernel, every distribution in wsl will use 
+Note: once you replace the wsl linux kernel with the custom kernel, every distribution will use that same kernel. 
 
 ## Generate SSH key
 Make sure the public SSH key is associated with the GitHub account. [Here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) are some instructions on how to create an ssh key on your machine.
@@ -9,7 +9,7 @@ In Windows, open a WSL terminal and launch `vcan-in-wsl2.sh` script:
 ./vcan-in-wsl2.sh
 ```
 
-You will be asked to continue with the installation of `dwarves v1.21`. Alternative, it could be possible to use a newer version of dwarves by [skipping the btf encoding from the `pahole` invoke in the kernel build](https://unix.stackexchange.com/questions/754325/failed-load-btf-from-vmlinux-invalid-argument-make-on-config-debug-info-btf-y/772051#772051), however this hasn't been tested. Type `y` and `ENTER`.
+You will be asked to continue with the installation of `dwarves v1.21`. Type `y` and `ENTER`. Alternatively, it could be possible to use a newer version of dwarves by [skipping the btf encoding ](https://unix.stackexchange.com/questions/754325/failed-load-btf-from-vmlinux-invalid-argument-make-on-config-debug-info-btf-y/772051#772051) from the `pahole` invoke in the kernel build, however this hasn't been tested.
 
 Accept the default for all the kernel configuration requests.
 
@@ -28,9 +28,11 @@ From the user home directory, run the `wsl-reboot.ps1` script:
 ./wsl-reboot.ps1
 ```
 
-At completion, open a new wsl terminal and type `uname -a`. If the proces was successful, you should see the `5.15.57.1-microsoft-standard-WSL2+` in the output.
+At completion, open a new wsl terminal and type `uname -a`. If the process was successful, you should see the `5.15.57.1-microsoft-standard-WSL2+` in the output.
 
 Finally, launch the following command to add module from the linux kernel:
 ```
 sudo modprobe can; sudo modprobe can-raw; sudo modprobe vcan; sudo modprobe slcan; sudo modprobe can-isotp; sudo modprobe peak_usb; sudo modprobe kvaser_usb
 ```
+
+If all the modules were correctly installed, you should see no output from the command above.

--- a/vcan-in-wsl2/README.md
+++ b/vcan-in-wsl2/README.md
@@ -3,3 +3,13 @@
 In Windows, open a WSL terminal and launch `vcan-in-wsl2.sh` script.
 
 A Linux Kernel Configuration menu will open. In the `General Setup` section, we can select vcan and slcan (press M for module support)
+
+Go to Networking support
+M CAN bus subsystem support
+M ISO 15765-2:2016 CAN transport protocol
+
+Go to CAN Device Drivers
+M Virtual Local CAN Interface (vcan)
+M Serial / USB serial CAN Adaptors (slcan)
+M Kvaser PCIe FD Cards
+M PEAK-System PCAN-PCIe FD cards

--- a/vcan-in-wsl2/README.md
+++ b/vcan-in-wsl2/README.md
@@ -1,0 +1,5 @@
+## WSL CLI
+
+In Windows, open a WSL terminal and launch `vcan-in-wsl2.sh` script.
+
+A Linux Kernel Configuration menu will open. In the `General Setup` section, we can select vcan and slcan (press M for module support)

--- a/vcan-in-wsl2/README.md
+++ b/vcan-in-wsl2/README.md
@@ -1,15 +1,36 @@
-## WSL CLI
 
+## Generate SSH key
+Make sure the public SSH key is associated with the GitHub account. 
+
+## WSL CLI
 In Windows, open a WSL terminal and launch `vcan-in-wsl2.sh` script.
 
-A Linux Kernel Configuration menu will open. In the `General Setup` section, we can select vcan and slcan (press M for module support)
+You will be asked to continue with the installation of `dwarves v1.21`. Type `y` and `ENTER`.
 
-Go to Networking support
-M CAN bus subsystem support
-M ISO 15765-2:2016 CAN transport protocol
+Accept the default for all the kernel configuration requests.
 
-Go to CAN Device Drivers
-M Virtual Local CAN Interface (vcan)
-M Serial / USB serial CAN Adaptors (slcan)
-M Kvaser PCIe FD Cards
-M PEAK-System PCAN-PCIe FD cards
+Subsequently, a linux kernel configuration menu will open. In the `General Setup` section, we need to  enable support for vcan and slcan. Use `ENTER` to access sub-configurations and `M` for module support
+
+`ENTER` Networking support
+
+->`M` CAN bus subsystem support
+
+-> `M` ISO 15765-2:2016 CAN transport protocol
+
+`ENTER` Go to CAN Device Drivers
+
+-> `M` Virtual Local CAN Interface (vcan)
+
+-> `M` Serial / USB serial CAN Adaptors (slcan)
+
+-> `M` Kvaser PCIe FD Cards
+
+-> `M` PEAK-System PCAN-PCIe FD cards
+
+## Powershell
+
+Once the `vcan-in-wsl2.sh` script is done, close the wsl terminal and run a powershell as administrator.
+
+From the user home directory, run the `wsl-reboot.ps1` script.
+
+At completion, open a new wsl terminal and type `uname -a`. If the proces was successful, you should see the `5.15.57.1-microsoft-standard-WSL2+` in the output

--- a/vcan-in-wsl2/vcan-in-wsl2.sh
+++ b/vcan-in-wsl2/vcan-in-wsl2.sh
@@ -1,4 +1,5 @@
 # required packages
+sudo apt update -y && sudo apt upgrade -y
 sudo apt install -y libelf-dev flex bison libssl-dev libncurses-dev bc
 
 # The v1.21 of dwarves (and its dependency pahole) is required. Download it in your preferred directory and install it

--- a/vcan-in-wsl2/vcan-in-wsl2.sh
+++ b/vcan-in-wsl2/vcan-in-wsl2.sh
@@ -1,5 +1,8 @@
 # #!/bin/bash
 
+# Exit if an error occurs
+set -e
+
 # Get the directory of the script
 SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -7,7 +10,7 @@ SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo !!!!!!!!!!!!!!!!!!!!!!!!!
 echo Install required packages
 echo !!!!!!!!!!!!!!!!!!!!!!!!!
-sudo apt update -y && sudo apt upgrade -y
+sudo apt update -y
 sudo apt install -y libelf-dev flex bison libssl-dev libncurses-dev bc build-essential make
 sudo apt install -y --no-install-recommends wslu
 
@@ -25,7 +28,7 @@ sudo apt install ./dwarves_1.21-0ubuntu1~20.04.1_amd64.deb
 echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 echo Clone and checkout the WSL2 Linux Kernel
 echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-if [[ ! -d "/WSL2-Linux-Kernel/" ]]; then
+if [[ ! -d "./WSL2-Linux-Kernel/" ]]; then
     git clone git@github.com:microsoft/WSL2-Linux-Kernel.git --shallow-since=2022-07-30
 fi
 cd WSL2-Linux-Kernel/
@@ -59,4 +62,4 @@ cd $WIN_USER
 touch .wslconfig
 cd $SCRIPT_PATH
 cp wsl-reboot.ps1 $WIN_USER
-echo Done! Now open a Windows powershell and launch the wsl-reboot.ps1 script to reboot WSL with the custom linux kernel.
+echo Done! Now close this terminal, open a Windows powershell and launch the wsl-reboot.ps1 script to reboot WSL with the custom linux kernel.

--- a/vcan-in-wsl2/vcan-in-wsl2.sh
+++ b/vcan-in-wsl2/vcan-in-wsl2.sh
@@ -1,5 +1,7 @@
-#!/bin/bash
-SCRIPT_PATH="$(dirname "$0")"
+# #!/bin/bash
+
+# Get the directory of the script
+SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Update and install required packages
 echo !!!!!!!!!!!!!!!!!!!!!!!!!
@@ -7,13 +9,17 @@ echo Install required packages
 echo !!!!!!!!!!!!!!!!!!!!!!!!!
 sudo apt update -y && sudo apt upgrade -y
 sudo apt install -y libelf-dev flex bison libssl-dev libncurses-dev bc build-essential make
+sudo apt install -y --no-install-recommends wslu
 sleep 5
 
 # The v1.21 of dwarves (and its dependency pahole) is required.
 echo !!!!!!!!!!!!!!!!!!!!!
 echo Install dwarves v1.21
 echo !!!!!!!!!!!!!!!!!!!!!
+if [[ ! -f "dwarves_1.21-0ubuntu1~20.04.1_amd64.deb" ]]; then
+echo !!!!!!!!!!!!!!Downloading dwarves 1.21!!!!!!!!!!!!!!!!!!!!!
 wget http://archive.ubuntu.com/ubuntu/pool/universe/d/dwarves-dfsg/dwarves_1.21-0ubuntu1~20.04.1_amd64.deb
+fi
 sudo apt install ./dwarves_1.21-0ubuntu1~20.04.1_amd64.deb
 sleep 5
 
@@ -22,7 +28,7 @@ echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 echo Clone and checkout the WSL2 Linux Kernel
 echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 if [[ ! -d "/WSL2-Linux-Kernel/" ]]; then
-    git clone https://github.com/microsoft/WSL2-Linux-Kernel --shallow-since=2022-07-30
+    git clone git@github.com:microsoft/WSL2-Linux-Kernel.git --shallow-since=2022-07-30
 fi
 cd WSL2-Linux-Kernel/
 git checkout linux-msft-wsl-5.15.57.1 # This version has canfd drivers as well as regular can drivers
@@ -41,24 +47,26 @@ sleep 5
 echo !!!!!!!!!!!!
 echo Build kernel
 echo !!!!!!!!!!!!
-make -j$(nproc)
+make -j$(( $(nproc) - 1 ))
 sudo make modules_install
 sudo ln -s /lib/modules/5.15.57.1-microsoft-standard-WSL2+/ /lib/modules/5.15.57.1-microsoft-standard-WSL2
 sleep 5
 
 # Find and store Windows username
-WIN_USER=$(powershell.exe '$env:UserName')
+WIN_USER=$(wslpath "$(wslvar USERPROFILE)")
 
 # Copy kernel to Windows home directory
 echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 echo Copy kernel and wsl-reboot.sh to Windows
 echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-cp vmlinux /mnt/c/Users/$WIN_USER/
-cat >> /mnt/c/Users/$WIN_USER/.wslconfig << "ENDL"
+cp vmlinux $WIN_USER/
+cd $WIN_USER
+touch .wslconfig
+cat >> .wslconfig << "ENDL"
 [wsl2]
 kernel=C:\\Users\\$WIN_USER\\vmlinux
 ENDL
 cd $SCRIPT_PATH
-cp wsl-reboot.ps1 /mnt/c/Users/$WIN_USER/
-
+echo $SCRIPT_PATH
+cp wsl-reboot.ps1 $WIN_USER
 echo Done! Now open a Windows powershell and launch the wsl-reboot.ps1 script to reboot WSL.

--- a/vcan-in-wsl2/vcan-in-wsl2.sh
+++ b/vcan-in-wsl2/vcan-in-wsl2.sh
@@ -1,11 +1,14 @@
 # required packages
-sudo apt install -y libelf-dev dwarves flex bison libssl-dev \
-    libncurses-dev
- 
+sudo apt install -y libelf-dev flex bison libssl-dev libncurses-dev bc
+
+# The v1.21 of dwarves (and its dependency pahole) is required. Download it in your preferred directory and install it
+wget http://archive.ubuntu.com/ubuntu/pool/universe/d/dwarves-dfsg/dwarves_1.21-0ubuntu1~20.04.1_amd64.deb
+sudo apt install ./dwarves_1.21-0ubuntu1~20.04.1_amd64.deb
+
 # The below few connamds will checkout the 1GB default kernel
-git clone https://github.com/microsoft/WSL2-Linux-Kernel
+git clone https://github.com/microsoft/WSL2-Linux-Kernel --shallow-since=2022-07-30
 cd WSL2-Linux-Kernel/
-git checkout linux-msft-wsl-`uname -r | cut -d'-' -f1 |  tr -d '\n'`
+git checkout linux-msft-wsl-5.15.57.1 # This version has canfd drivers as well as regular can drivers
 cat /proc/config.gz | gunzip > .config
 make prepare modules_prepare
  
@@ -17,10 +20,10 @@ make prepare modules_prepare
 # https://www.kernelconfig.io/config_can_vcan
 make menuconfig 
 
-#build the kernel
-make -j4
-sudo make module_install
-sudo ln -s /lib/modules/5.10.16.3-microsoft-standard-WSL2+/ /lib/modules/5.10.16.3-microsoft-standard-WSL2
+# build the kernel
+make -j$(nproc)
+sudo make modules_install
+sudo ln -s /lib/modules/5.15.57.1-microsoft-standard-WSL2+/ /lib/modules/5.15.57.1-microsoft-standard-WSL2
 # We'll need to store our custom kernel in the Windows environment and 
 # launch it when we start wsl2.
 # Change the path below to where you want to store it
@@ -36,3 +39,5 @@ ENDL
 # Wait 10 seconds or check everything is stopped with
 # wsl --list -v
 
+## Check new custom kernel is used
+uname -a

--- a/vcan-in-wsl2/vcan-in-wsl2.sh
+++ b/vcan-in-wsl2/vcan-in-wsl2.sh
@@ -10,7 +10,6 @@ echo !!!!!!!!!!!!!!!!!!!!!!!!!
 sudo apt update -y && sudo apt upgrade -y
 sudo apt install -y libelf-dev flex bison libssl-dev libncurses-dev bc build-essential make
 sudo apt install -y --no-install-recommends wslu
-sleep 5
 
 # The v1.21 of dwarves (and its dependency pahole) is required.
 echo !!!!!!!!!!!!!!!!!!!!!
@@ -21,7 +20,6 @@ echo !!!!!!!!!!!!!!Downloading dwarves 1.21!!!!!!!!!!!!!!!!!!!!!
 wget http://archive.ubuntu.com/ubuntu/pool/universe/d/dwarves-dfsg/dwarves_1.21-0ubuntu1~20.04.1_amd64.deb
 fi
 sudo apt install ./dwarves_1.21-0ubuntu1~20.04.1_amd64.deb
-sleep 5
 
 # Clone and checkout the WSL2 Linux Kernel
 echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -34,14 +32,12 @@ cd WSL2-Linux-Kernel/
 git checkout linux-msft-wsl-5.15.57.1 # This version has canfd drivers as well as regular can drivers
 cat /proc/config.gz | gunzip > .config
 make prepare modules_prepare
-sleep 5
 
 # Configure kernel
 echo !!!!!!!!!!!!!!!!
 echo Configure kernel
 echo !!!!!!!!!!!!!!!!
 make menuconfig 
-sleep 5
 
 # Build the kernel
 echo !!!!!!!!!!!!
@@ -50,7 +46,6 @@ echo !!!!!!!!!!!!
 make -j$(( $(nproc) - 1 ))
 sudo make modules_install
 sudo ln -s /lib/modules/5.15.57.1-microsoft-standard-WSL2+/ /lib/modules/5.15.57.1-microsoft-standard-WSL2
-sleep 5
 
 # Find and store Windows username
 WIN_USER=$(wslpath "$(wslvar USERPROFILE)")
@@ -62,11 +57,6 @@ echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 cp vmlinux $WIN_USER/
 cd $WIN_USER
 touch .wslconfig
-cat >> .wslconfig << "ENDL"
-[wsl2]
-kernel=C:\\Users\\$WIN_USER\\vmlinux
-ENDL
 cd $SCRIPT_PATH
-echo $SCRIPT_PATH
 cp wsl-reboot.ps1 $WIN_USER
-echo Done! Now open a Windows powershell and launch the wsl-reboot.ps1 script to reboot WSL.
+echo Done! Now open a Windows powershell and launch the wsl-reboot.ps1 script to reboot WSL with the custom linux kernel.

--- a/vcan-in-wsl2/vcan-in-wsl2.sh
+++ b/vcan-in-wsl2/vcan-in-wsl2.sh
@@ -1,44 +1,64 @@
-# required packages
-sudo apt update -y && sudo apt upgrade -y
-sudo apt install -y libelf-dev flex bison libssl-dev libncurses-dev bc
+#!/bin/bash
+SCRIPT_PATH="$(dirname "$0")"
 
-# The v1.21 of dwarves (and its dependency pahole) is required. Download it in your preferred directory and install it
+# Update and install required packages
+echo !!!!!!!!!!!!!!!!!!!!!!!!!
+echo Install required packages
+echo !!!!!!!!!!!!!!!!!!!!!!!!!
+sudo apt update -y && sudo apt upgrade -y
+sudo apt install -y libelf-dev flex bison libssl-dev libncurses-dev bc build-essential make
+sleep 5
+
+# The v1.21 of dwarves (and its dependency pahole) is required.
+echo !!!!!!!!!!!!!!!!!!!!!
+echo Install dwarves v1.21
+echo !!!!!!!!!!!!!!!!!!!!!
 wget http://archive.ubuntu.com/ubuntu/pool/universe/d/dwarves-dfsg/dwarves_1.21-0ubuntu1~20.04.1_amd64.deb
 sudo apt install ./dwarves_1.21-0ubuntu1~20.04.1_amd64.deb
+sleep 5
 
-# The below few connamds will checkout the 1GB default kernel
-git clone https://github.com/microsoft/WSL2-Linux-Kernel --shallow-since=2022-07-30
+# Clone and checkout the WSL2 Linux Kernel
+echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+echo Clone and checkout the WSL2 Linux Kernel
+echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+if [[ ! -d "/WSL2-Linux-Kernel/" ]]; then
+    git clone https://github.com/microsoft/WSL2-Linux-Kernel --shallow-since=2022-07-30
+fi
 cd WSL2-Linux-Kernel/
 git checkout linux-msft-wsl-5.15.57.1 # This version has canfd drivers as well as regular can drivers
 cat /proc/config.gz | gunzip > .config
 make prepare modules_prepare
- 
-# The next command brings up the kernel configuration.
-# In here we can select vcan and slcan.(PRESS M for Module support). You can also enable other modules you
-# require and test if they work. The link below helps locate modules in the
-# menu config display. For wsl v5.10.102 it was located at:
-# Networking support -> CAN bus subsystem support -> CaN Device Drivers -> vcan
-# https://www.kernelconfig.io/config_can_vcan
-make menuconfig 
+sleep 5
 
-# build the kernel
+# Configure kernel
+echo !!!!!!!!!!!!!!!!
+echo Configure kernel
+echo !!!!!!!!!!!!!!!!
+make menuconfig 
+sleep 5
+
+# Build the kernel
+echo !!!!!!!!!!!!
+echo Build kernel
+echo !!!!!!!!!!!!
 make -j$(nproc)
 sudo make modules_install
 sudo ln -s /lib/modules/5.15.57.1-microsoft-standard-WSL2+/ /lib/modules/5.15.57.1-microsoft-standard-WSL2
-# We'll need to store our custom kernel in the Windows environment and 
-# launch it when we start wsl2.
-# Change the path below to where you want to store it
-cp vmlinux /mnt/c/Users/<USER>/
-cat >> /mnt/c/Users/<USER>/.wslconfig << "ENDL"
+sleep 5
+
+# Find and store Windows username
+WIN_USER=$(powershell.exe '$env:UserName')
+
+# Copy kernel to Windows home directory
+echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+echo Copy kernel and wsl-reboot.sh to Windows
+echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+cp vmlinux /mnt/c/Users/$WIN_USER/
+cat >> /mnt/c/Users/$WIN_USER/.wslconfig << "ENDL"
 [wsl2]
-kernel=C:\\Users\\<USER>\\vmlinux
+kernel=C:\\Users\\$WIN_USER\\vmlinux
 ENDL
+cd $SCRIPT_PATH
+cp wsl-reboot.ps1 /mnt/c/Users/$WIN_USER/
 
-# We'll need to restart WSL to use the new kernel
-# In the command prompt enter the next couple of commands
-# wsl --shutdown
-# Wait 10 seconds or check everything is stopped with
-# wsl --list -v
-
-## Check new custom kernel is used
-uname -a
+echo Done! Now open a Windows powershell and launch the wsl-reboot.ps1 script to reboot WSL.

--- a/vcan-in-wsl2/wsl-reboot.ps1
+++ b/vcan-in-wsl2/wsl-reboot.ps1
@@ -1,0 +1,23 @@
+# Function to shut down WSL
+function Stop-WSL {
+    # Stop WSL
+    wsl --shutdown
+}
+
+# Function to check the list of running WSL instances
+function Check-WSLList {
+    # Get list of running WSL instances
+    $wslList = wsl --list --running
+
+    # Output the list
+    Write-Output $wslList
+}
+
+# Shut down WSL
+Stop-WSL
+
+# Wait for 10 seconds
+Start-Sleep -Seconds 10
+
+# Check the list of running WSL instances
+Check-WSLList

--- a/vcan-in-wsl2/wsl-reboot.ps1
+++ b/vcan-in-wsl2/wsl-reboot.ps1
@@ -7,11 +7,22 @@ function Stop-WSL {
 # Function to check the list of running WSL instances
 function Check-WSLList {
     # Get list of running WSL instances
-    $wslList = wsl --list --running
+    $wslList = wsl --list -v
 
     # Output the list
     Write-Output $wslList
 }
+
+# Get the Windows username
+$WIN_USER = $env:USERNAME
+
+# Construct the kernel path
+$kernel_path = "C:\\Users\\$WIN_USER\\vmlinux"
+
+# Add the lines to the file
+Add-Content -Path "C:\\Users\\$WIN_USER\\.wslconfig" -Value "[wsl2]"
+Add-Content -Path "C:\\Users\\$WIN_USER\\.wslconfig" -Value "kernel=$kernel_path"
+
 
 # Shut down WSL
 Stop-WSL


### PR DESCRIPTION
The changes in this PR automate the WSL2 Linux kernel customization to support vcan and slcan.

The process completes via 2 scripts:

- `vcan-in-wsl2.sh` installs the required dependencies, downloads the WSL2 linux kernel, enables its configuration and copies the custom kernel in the Windows home directory.
- `wsl-reboot.ps1` write the linux kernel path in wsl global configuration file and shuts down wsl.

Instructions are added to the `README.md`